### PR TITLE
Switch to commands.Bot() instance

### DIFF
--- a/src/discobase/database.py
+++ b/src/discobase/database.py
@@ -7,8 +7,8 @@ from typing import Type, TypeVar
 
 import discord
 import orjson
-
 from discord.ext import commands
+
 from .table import Table
 
 __all__ = ("Database",)


### PR DESCRIPTION
Changed discord.Client() to commands.Bot(). Included prefix "!" as it is a mandatory argument, but wont be utilized.