### PR TITLE
Partial implementation of caching and structured concurrency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "discobase"
 readme = "README.md"
 license = "MIT"
-dependencies = ["discord.py", "pydantic", "typing_extensions", "loguru"]
+dependencies = ["discord.py", "pydantic", "typing_extensions", "loguru", "aiocache"]
 dynamic = ["version"]
 
 [tool.ruff]

--- a/src/discobase/_cursor.py
+++ b/src/discobase/_cursor.py
@@ -14,6 +14,7 @@ from loguru import logger
 from pydantic import BaseModel, ValidationError
 
 from ._metadata import Metadata
+from ._util import gather_group
 from .exceptions import DatabaseCorruptionError, DatabaseStorageError
 
 if TYPE_CHECKING:
@@ -587,18 +588,21 @@ class TableCursor:
         )
         message = await main_table.send(record_data.model_dump_json())
 
-        for field, value in record.model_dump().items():
-            channel = self._find_channel(
-                metadata.index_channels[f"{record.__disco_name__}_{field}"]
-            )
-            # TODO: Use gather here
-            hashed_field, target_index = self._as_hashed(value)
-            await self._write_index_record(
-                channel,
-                target_index,
-                hashed_field,
-                message.id,
-            )
+        async with gather_group() as group:
+            for field, value in record.model_dump().items():
+                channel = self._find_channel(
+                    metadata.index_channels[f"{record.__disco_name__}_{field}"]
+                )
+                # TODO: Use gather here
+                hashed_field, target_index = self._as_hashed(value)
+                group.add(
+                    self._write_index_record(
+                        channel,
+                        target_index,
+                        hashed_field,
+                        message.id,
+                    )
+                )
 
         return await message.edit(content=record_data.model_dump_json())
 

--- a/src/discobase/_util.py
+++ b/src/discobase/_util.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Coroutine
 from contextlib import asynccontextmanager
-from typing import Any, TypeVar
+from typing import Any, Coroutine, TypeVar
 
 import discord
 from loguru import logger
@@ -25,7 +24,7 @@ class GatherGroup:
                 except discord.HTTPException as e:
                     if e.code == 429:
                         logger.warning("Ratelimited! Retrying...")
-                        await asyncio.sleep(1)
+                        await asyncio.sleep(0.1)
 
         task = asyncio.create_task(inner_coro())
         self.tasks.append(task)

--- a/src/discobase/_util.py
+++ b/src/discobase/_util.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine
+from contextlib import asynccontextmanager
+from typing import Any, TypeVar
+
+from loguru import logger
+
+__all__ = "gather_group", "GatherGroup", "free_fly"
+
+T = TypeVar("T")
+
+
+class GatherGroup:
+    def __init__(self) -> None:
+        self.tasks: list[asyncio.Task] = []
+
+    def add(self, awaitable: Coroutine[Any, Any, T]) -> asyncio.Task[T]:
+        task = asyncio.create_task(awaitable)
+        self.tasks.append(task)
+        return task
+
+
+# A partial reimplementation of asyncio.TaskGroup, but
+# that's only on 3.11+ anyway.
+@asynccontextmanager
+async def gather_group():
+    group = GatherGroup()
+
+    try:
+        yield group
+    finally:
+        logger.debug(f"Gathering tasks: {group.tasks}")
+        await asyncio.gather(*group.tasks)
+
+
+_TASKS = set()
+
+
+def free_fly(coro: Coroutine[Any, Any, T]) -> asyncio.Task[T]:
+    task = asyncio.create_task(coro)
+    _TASKS.add(task)
+    task.add_done_callback(_TASKS.discard)
+    return task

--- a/src/discobase/table.py
+++ b/src/discobase/table.py
@@ -94,6 +94,7 @@ class Table(BaseModel):
             msg = fut.result()
             self.__disco_id__ = msg.id
 
+        task.add_done_callback(_cb)
         return task
 
     def _ensure_written(self) -> None:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -167,6 +167,7 @@ async def test_long_resize(database: discobase.Database):
 #     assert len(await Whatever.find()) == 0
 
 
+@pytest.mark.asyncio(scope="session")
 async def test_delete(database: discobase.Database):
     @database.table
     class DeleteTest(discobase.Table):


### PR DESCRIPTION
This is a partial implementation of #60. This is mostly structured concurrency, not caching. Some bottlenecks I noticed when testing:

- Hash collision searches.
- Slash command sync.
- Task gathering (although, that's technically by design, and is heavy on the ratelimit).
- Parsing takes a bit of time -- we can simply cache that.
- General message lookup, but that's not really something we can fix.