### PR TITLE
Fix docs

### DIFF
--- a/docs/discord_interface.md
+++ b/docs/discord_interface.md
@@ -32,9 +32,9 @@ The `/schema` operation takes in the name of your table as input and outputs inf
 
 ### Limitation
 
-Considering the limit of fields is 25 on discord. The command can only show up to 25 columns, so we'll signify the limit as `field_length = 25` forming the following inequality:
+!!! warning "Limitation"
 
-**C** <= `field_length` where **C** is the number of columns.
+    -   Considering the limit of fields is 25 on discord. The command can only show up to 25 columns, so we'll signify the limit as `field_length = 25` forming the following inequality: **C** <= `field_length` where **C** is the number of columns.
 
 ## Update a Column's Value
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ nav:
     - Core Library: library.md
     - Discord Interface: discord_interface.md
     - API Reference: reference.md
+    - Demonstration: demonstration.md
 
 theme:
     name: material


### PR DESCRIPTION
Fixes the `demonstration.md` not showing up in the docs navigation and adds the warning styling to the limitation in schema that was missing.